### PR TITLE
demonstrate the issue

### DIFF
--- a/api/api/main.py
+++ b/api/api/main.py
@@ -1,5 +1,4 @@
 import anyio
-import anyio._backends._asyncio as anyio_asyncio
 from fastapi import Depends, FastAPI
 from sqlalchemy.orm import Session
 
@@ -12,7 +11,8 @@ app = FastAPI()
 
 @app.on_event("startup")
 def startup():
-    anyio_asyncio._default_thread_limiter.set(anyio.CapacityLimiter(4096))
+    limiter = anyio.to_thread.current_default_thread_limiter()
+    limiter.total_tokens = 4096
     Base.metadata.create_all(bind=engine)
 
 

--- a/api/api/main.py
+++ b/api/api/main.py
@@ -1,3 +1,5 @@
+import anyio
+import anyio._backends._asyncio as anyio_asyncio
 from fastapi import Depends, FastAPI
 from sqlalchemy.orm import Session
 
@@ -10,6 +12,7 @@ app = FastAPI()
 
 @app.on_event("startup")
 def startup():
+    anyio_asyncio._default_thread_limiter.set(anyio.CapacityLimiter(4096))
     Base.metadata.create_all(bind=engine)
 
 


### PR DESCRIPTION
The default value is 40: only 40 dependencies / sync endpoints can run at a time, total in the entire app. So as soon as you hit ~40 concurrent requests, things will deadlock.

With this change I get:

```
Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    4   4.3      3      12
Processing:    35  306 169.5    297     759
Waiting:       24  304 169.5    294     759
Total:         35  309 170.9    305     764
```

And no lockups